### PR TITLE
Support local declarations

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,5 +5,6 @@
 
 ## 0.1.1.0
 - follow `INLINE` pragmas when adding loopbreakers
+- support local declarations (`let` and `where` bindings)
 
 ## Unreleased changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
 # Changelog for Loopbreaker
 
+## 0.1.0.0
+- initial release
+
+## 0.1.1.0
+- follow `INLINE` pragmas when adding loopbreakers
+
 ## Unreleased changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,10 +1,10 @@
 # Changelog for Loopbreaker
 
-## 0.1.0.0
-- initial release
-
 ## 0.1.1.0
 - follow `INLINE` pragmas when adding loopbreakers
 - support local declarations (`let` and `where` bindings)
+
+## 0.1.0.0
+- initial release
 
 ## Unreleased changes

--- a/loopbreaker.cabal
+++ b/loopbreaker.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1509557f4dc0308eb9d18b550529d64c787c36cb11f112eea86ab99b06351d6e
+-- hash: 7d40ff9eb6d5bfa16d7cf23db04b05f9f1c18aa7fc44eb0249fb96accd7f3a56
 
 name:           loopbreaker
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       inline self-recursive definitions
 description:    Please see the README file on Github for more info
 category:       Plugin

--- a/package.yaml
+++ b/package.yaml
@@ -1,7 +1,7 @@
 name        : loopbreaker
 synopsis    : inline self-recursive definitions
 description : Please see the README file on Github for more info
-version     : 0.1.0.0
+version     : 0.1.1.0
 category    : Plugin
 github      : "polysemy-research/loopbreaker"
 license     : BSD3

--- a/test/InlineRecCallsSpec.hs
+++ b/test/InlineRecCallsSpec.hs
@@ -16,8 +16,10 @@ spec = describe "plugin" $ do
   -- TODO: implementation as Core pass to resolve this
   -- it "should work without signatures" $ do
   --   shouldSucceed $(inspectTest $ 'recursiveNoSig === 'mutual)
-  it "should explicitly break recursion in local bindings" $ do
-    shouldSucceed $(inspectTest $ 'localRecursive === 'localMutual)
+  it "should explicitly break recursion in where bindings" $ do
+    shouldSucceed $(inspectTest $ 'localRecursiveWhere === 'localMutual)
+  it "should explicitly break recursion in let bindings" $ do
+    shouldSucceed $(inspectTest $ 'localRecursiveLet === 'localMutual)
 
 ------------------------------------------------------------------------------
 recursive :: Int -> Int
@@ -38,11 +40,19 @@ mutual' :: Int -> Int
 mutual' = mutual
 {-# NOINLINE mutual' #-}
 
-localRecursive :: Int -> Int
-localRecursive = local where
+localRecursiveWhere :: Int -> Int
+localRecursiveWhere = local where
   local 0 = 1
   local n = n * local (n - 1)
   {-# INLINE local #-}
+
+localRecursiveLet :: Int -> Int
+localRecursiveLet = let
+  local 0 = 1
+  local n = n * local (n - 1)
+  {-# INLINE local #-}
+ in
+  local
 
 localMutual :: Int -> Int
 localMutual = local where

--- a/test/InlineRecCallsSpec.hs
+++ b/test/InlineRecCallsSpec.hs
@@ -11,14 +11,23 @@ import TestUtils
 -- TODO: more tests
 spec :: Spec
 spec = describe "plugin" $ do
-  it "should explicitly break recursion" $ do
+  it "should explicitly break recursion in global bindings" $ do
     shouldSucceed $(inspectTest $ 'recursive === 'mutual)
+  -- TODO: implementation as Core pass to resolve this
+  -- it "should work without signatures" $ do
+  --   shouldSucceed $(inspectTest $ 'recursiveNoSig === 'mutual)
+  it "should explicitly break recursion in local bindings" $ do
+    shouldSucceed $(inspectTest $ 'localRecursive === 'localMutual)
 
 ------------------------------------------------------------------------------
 recursive :: Int -> Int
 recursive 0 = 1
 recursive n = n * recursive (n - 1)
 {-# INLINE recursive #-}
+
+-- recursiveNoSig 0 = (1 :: Int)
+-- recursiveNoSig n = n * recursiveNoSig (n - 1)
+-- {-# INLINE recursiveNoSig #-}
 
 mutual :: Int -> Int
 mutual 0 = 1
@@ -28,3 +37,18 @@ mutual n = n * mutual' (n - 1)
 mutual' :: Int -> Int
 mutual' = mutual
 {-# NOINLINE mutual' #-}
+
+localRecursive :: Int -> Int
+localRecursive = local where
+  local 0 = 1
+  local n = n * local (n - 1)
+  {-# INLINE local #-}
+
+localMutual :: Int -> Int
+localMutual = local where
+  local 0 = 1
+  local n = n * local' (n - 1)
+  {-# INLINE local #-}
+
+  local' = local
+  {-# NOINLINE local' #-}


### PR DESCRIPTION
This should make it possible to remove all manual definitions in `polysemy`. But it's only a temporary solution - we are going to rewrite plugin in terms of Core representation to resolve problems with signatures.